### PR TITLE
Fix case of 'reprocessing' dependency

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "reprocessing-example",
   "sources": "src",
-  "bs-dependencies": ["Reprocessing"],
+  "bs-dependencies": ["reprocessing"],
   "entries": [{
     "backend": "bytecode",
     "main-module": "IndexHot"


### PR DESCRIPTION
Looks like this closes #1 (though I still have a problem with
initializing audio on startup :( )

For systems with case-sensitive filesystems